### PR TITLE
Limit URLs that can be opened by shell.openExternal in redirects from login consent requests.

### DIFF
--- a/routes/api/plugin/builtin/loginconsentui.js
+++ b/routes/api/plugin/builtin/loginconsentui.js
@@ -26,6 +26,12 @@ module.exports = (api) => {
       },
       [LOGIN_CONSENT_REDIRECT_VDXF_KEY.vdxfid]: () => {
         const url = new URL(uri)
+
+        // Prevent opening any urls that don't go to the browser.
+        if (!['https:', 'http:'].includes(url.protocol)) {
+          return null;
+        } 
+
         const res = new LoginConsentResponse(response)
         url.searchParams.set(
           LOGIN_CONSENT_RESPONSE_VDXF_KEY.vdxfid,


### PR DESCRIPTION
After a login consent request is completed, it can redirect to a URL that was provided in the request. This change prevents redirecting to URLs that are not either http or https as to avoid RCEs.